### PR TITLE
防止在微信中打开时报错

### DIFF
--- a/src/apis.ts
+++ b/src/apis.ts
@@ -5,7 +5,7 @@ declare const wx: any
 function processApis (taro) {
   taro.qy = {}
 
-  Object.keys(wx.qy).forEach(key => {
+  Object.keys(wx.qy || {}).forEach(key => {
     if (needPromiseApis.has(key)) {
       taro.qy[key] = (options, ...args) => {
         options = options || {}


### PR DESCRIPTION
微信（非企业微信）中，不存在 wx.qy，直接使用 Object.keys(wx.qy) 会导致 Uncaught TypeError: Cannot convert undefined or null to object。
------------------------------------------------------------------------
适用场景：
1. 一个小程序既需要兼容微信、又需要兼容企业微信；
2. 在如果用户在微信中通过某种方式访问到原本企业微信才能访问的小程序，需要有个页面能引导用户到企业微信中使用（现在是直接报错然后白屏）。